### PR TITLE
z-eves-gui.sh fixed, only if pwd is z-eves

### DIFF
--- a/Z-Eves/system/z-eves-gui.sh
+++ b/Z-Eves/system/z-eves-gui.sh
@@ -8,9 +8,14 @@
 # path, and make it executable. You may also have to change the definition of
 # the python variable.
 
-zevesdir=/opt/Z/Z-Eves/
+realpaththisfile=$(realpath $0)
+#zevesdir=/opt/Z/Z-Eves/
+thisfiledirectory=$(dirname $realpaththisfile)
+zevesdir=$(dirname $thisfiledirectory)
 zguidir=$zevesdir/gui-1.5
-python=/opt/Z/bin/python
+#python=/opt/Z/bin/python
+basezeves=$(dirname $zevesdir)
+python=$basezeves/bin/python
 
 
 lispdir=$zevesdir/system


### PR DESCRIPTION
#2 fix only if pwd is z-eves.
/Forked_Z_Eves/z-eves$ bash Z-Eves/system/z-eves-gui.sh -> works
But if I try to run from other directory:-
/Forked_Z_Eves$ bash z-eves/Z-Eves/system/z-eves-gui.sh
xset:  bad font path element (#3), possible causes are:
    Directory does not exist or has wrong permissions
    Directory missing fonts.dir
    Incorrect font server address or syntax
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Traceback (innermost last):
  File "../gui/toplevel.py", line 5, in ?
  File "../gui/GUI.py", line 87, in ?
  File "/home/rahul/Study/ArcitectingReliableSystem/Forked_Z_Eves/z-eves/lib/python1.5/lib-tk/Tkinter.py", line 886, in __init__
    self.tk = _tkinter.create(screenName, baseName, className)
TclError: Can't find a usable init.tcl in the following directories: 
    /opt/Z/lib/tcl8.0 ./lib/tcl8.0 ./lib/tcl8.0 ./library ./library ./tcl8.0/library ./tcl8.0/library

This probably means that Tcl wasn't installed properly.

Error!
All pyc files only. Maybe some hardcoded path inside python scripts.